### PR TITLE
Fixes BUG #128544. LWP::Protocol::https not installed

### DIFF
--- a/lib/URI/Title.pm
+++ b/lib/URI/Title.pm
@@ -13,6 +13,7 @@ use Module::Pluggable (search_path => ['URI::Title'], require => 1 );
 use File::Type;
 
 use LWP::UserAgent;
+use LWP::Protocol::https;
 use HTTP::Request;
 use HTTP::Response;
 


### PR DESCRIPTION
Fixes BUG #128544 : Test suite fails without LWP::Protocol::https
See  https://rt.cpan.org/Public/Bug/Display.html?id=128544

Hello, this is my first assignment from https://pullrequest.club/ .
I have never used this module myself, but I like to would like to
contribute :)

Ok, so the failed test: `t/html.t`

```
ok(
  title('http://www.theregister.co.uk/2003/12/16/warning_lack_of_technology_may/') =~ /lack of technology may harm your prospects/,
  "got register title");
```

The reason for the failure seems to be that the document has moved to a https site,
and `LWP::UserAgent` then gets a 302 FOUND response, then retries with
new location:

https://www.theregister.co.uk/2003/12/16/warning_lack_of_technology_may/

which give a 501 response (since `LWP::Protocol::https` is not
installed) with message: "Protocol scheme 'https' is not
supported (LWP::Protocol::https not installed)". 

`URI::Title::title()` then returns a undefined value to `t/html.t`.

The reason why `LWP::Protocol::https` might not be installed can be
tracked back in its "Changes" file:

https://metacpan.org/source/OALDERS/LWP-Protocol-https-6.07/Changes

```
6.02      2011-03-27
    - Initial release of LWP-Protocol-https as a separate distribution. There
      are no code changes besides setting the version number since
      libwww-perl-6.01.
    - The LWP::Protocol::https module used to be bundled with the libwww-perl
      distribution, but it was unbundled in v6.02 in order to be able to declare
      its dependencies properly for the CPAN tool chain.  Applications that need
      https support can just declare their dependency on LWP::Protocol::https
      and will no longer need to know what underlying modules to
      install.
```

So I think we need to specify `LWP::Protocol::https` as a separate requirement
(if we are using a version of libwww-perl after 6.01).
I think this is best way to proceed is by adding it directly in `lib/URI/Title.pm`
```
use LWP::Protocol::https;
```
Then `Dist::Zilla::Plugin::AutoPrereqs` (from `dist.ini`) will
automatically add  `LWP::Protocol::https` to `PREREQ_PM` in the generated `Makefile.PL`.
 
