### PR TITLE
Fixes BUG #101272 : Special handling of spotify

### DIFF
--- a/lib/URI/Title.pm
+++ b/lib/URI/Title.pm
@@ -162,10 +162,7 @@ sub title {
         $type = "itms";
         $data = 1; # we don't need it, fake it.
 
-      } else {
-        # special case for spotify
-        $url =~ s{^(?:http://open.spotify.com/|spotify:)(\w+)[:/]}{http://spotify.url.fi/$1/};
-        
+    } else {
         $url =~ s{#!}{?_escaped_fragment_=};
 
         ($data, $cset) = _get_limited($url);

--- a/lib/URI/Title/HTML.pm
+++ b/lib/URI/Title/HTML.pm
@@ -68,9 +68,6 @@ sub title {
       # google can be used as a calculator. Try to find the result.
       $special_case = 'calc_img.*<td nowrap>(.+?)</td';
 
-    } elsif ($url =~ /spotify\.url\.fi/) {
-      $special_case = '<title>\s*(.+?)\s+&mdash;\s+Decode\s+Spotify\s+URIs\s*</title>';
-
     }
   }
 


### PR DESCRIPTION
Special handling of `http://open.spotify.com/` or the `spotify:` protocol to redirect to `http://spotify.url.fi` is no longer relevant since the site `http://spotify.url.fi` no longer exists, as mentioned in the [ticket #101272](https://rt.cpan.org/Public/Bug/Display.html?id=101272).

The relevant line in `lib/URI/Title.pm` is:
```
$url =~ s{^(?:http://open.spotify.com/|spotify:)(\w+)[:/]}{http://spotify.url.fi/$1/};
```

This line was introduced in commit 0085c50b4dcbb067b447358a79bcb052760e414a (from 2009) as a fix for [ticket #48231](https://rt.cpan.org/Public/Bug/Display.html?id=48231)

The regex tries to modify an URL on the form:

     http://open.spotify.com/xyz/rst

to

     http://spotify.url.fi/xyz/

or an URL of the form:

     spotify:xyz:rst 

to

     http://spotify.url.fi/xyz/


But that site: http://spotify.url.fi no longer exists, as mentioned by Peder Stray in the ticket.

Also the site: http://open.spotify.com/ currently redirects to the https site:
  https://open.spotify.com/browse/featured





